### PR TITLE
VAR-372, VAR-373 | Adjustments

### DIFF
--- a/app/components/Tooltip/index.js
+++ b/app/components/Tooltip/index.js
@@ -5,6 +5,7 @@ import { FormattedMessage, injectIntl } from 'react-intl';
 import classNames from 'classnames';
 import get from 'lodash/get';
 
+import SpaceAvailability from 'constants/SpaceAvailability';
 import isResourceAvailable from 'utils/isResourceAvailable';
 import getSpaceAvailability from 'utils/getSpaceAvailability';
 import getLocalizedString from 'utils/getLocalizedString';
@@ -23,6 +24,12 @@ import {
 import messages from './messages';
 import spaceTypeMessages from './spaceTypeMessages';
 import UserIcon from './icons/UserIcon';
+
+const ALLOWED_AVAILABILITIES = [
+  SpaceAvailability.AVAILABLE,
+  SpaceAvailability.TAKEN,
+  SpaceAvailability.CLOSED,
+];
 
 function SubSpaceVacancyIcon({ availableCount, totalCount }) {
   return (
@@ -134,7 +141,12 @@ function makeBody(content, currentLocal) {
     default: {
       const space = content[0];
       const vacancyStatus = getSpaceAvailability(space);
-      const maxPeopleCount = get(space, 'data.people_capacity', null);
+      const hardCodedMaxPeopleCount = get(space, 'peopleCapacity', null);
+      const maxPeopleCount = get(
+        space,
+        'data.people_capacity',
+        hardCodedMaxPeopleCount,
+      );
       const description = get(space, 'description', null);
       const name = get(space, 'data.name', space.name);
 
@@ -154,9 +166,11 @@ function makeBody(content, currentLocal) {
               <RowLabel>{translate(description)}</RowLabel>
             </Row>
           )}
-          <Row>
-            <VacancyLabel variant="light" vacancy={vacancyStatus} />
-          </Row>
+          {ALLOWED_AVAILABILITIES.includes(vacancyStatus) && (
+            <Row>
+              <VacancyLabel variant="light" vacancy={vacancyStatus} />
+            </Row>
+          )}
         </>
       );
     }

--- a/app/components/Tooltip/spaceTypeMessages.js
+++ b/app/components/Tooltip/spaceTypeMessages.js
@@ -37,4 +37,16 @@ export default defineMessages({
     id: `${scope}.buttonPinMachine`,
     defaultMessage: 'Rintanappikone',
   },
+  [SpaceTypes.ELECTRONIC_WORKSTATION]: {
+    id: `${scope}.electronicWorkstation`,
+    defaultMessage: 'Elektroniikkatyöpisteet',
+  },
+  [SpaceTypes.LASER_CUTTER]: {
+    id: `${scope}.laserCutter`,
+    defaultMessage: 'Laserleikkuri',
+  },
+  [SpaceTypes.UV_PRINTER]: {
+    id: `${scope}.uvPrinter`,
+    defaultMessage: 'Uv-tulostin',
+  },
 });

--- a/app/constants/SpaceTypes.js
+++ b/app/constants/SpaceTypes.js
@@ -7,4 +7,7 @@ export default Object.freeze({
   LARGE_FORMAT_PRINTER: 'largeFormatPrinter',
   VINYL_CUTTER_AND_HEATPRESS: 'vinylCutterAndHeatpress',
   BUTTON_PIN_MACHINE: 'buttonPinMachine',
+  ELECTRONIC_WORKSTATION: 'electronicWorkstation',
+  LASER_CUTTER: 'laserCutter',
+  UV_PRINTER: 'uvPrinter',
 });

--- a/app/containers/HomePage/spacesInitialState.js
+++ b/app/containers/HomePage/spacesInitialState.js
@@ -466,6 +466,9 @@ export default [
     category: Categories.OTHER_SPACES,
     room: Rooms.OTHER_5,
     id: '3',
+    // Disconnected from respa because the name of the sapce is counter
+    // intuitive to the categorisation used in this app, and because the
+    // reservation calendar for the application is not maanged in respa.
     // respaId: 'av5k7ixqvzha',
     name: {
       fi: 'Keittiö',

--- a/app/containers/HomePage/spacesInitialState.js
+++ b/app/containers/HomePage/spacesInitialState.js
@@ -466,7 +466,7 @@ export default [
     category: Categories.OTHER_SPACES,
     room: Rooms.OTHER_5,
     id: '3',
-    respaId: 'av5k7ixqvzha',
+    // respaId: 'av5k7ixqvzha',
     name: {
       fi: 'Keittiö',
     },
@@ -476,6 +476,7 @@ export default [
       sv: 'I köket kan våra kunder arrangera evenemang rörande matlagning',
       en: 'In the kitchen, customers can organize culinary related events',
     },
+    peopleCapacity: 10,
     canBeReserved: true,
   },
 ];

--- a/app/containers/HomePage/spacesInitialState.js
+++ b/app/containers/HomePage/spacesInitialState.js
@@ -379,10 +379,33 @@ export default [
   {
     category: Categories.MACHINE_ROOM,
     room: Rooms.MACHINE_ROOM_1,
+    type: SpaceTypes.ELECTRONIC_WORKSTATION,
     id: '47',
-    name: {
-      fi: 'Konehuone',
-    },
+    respaId: 'awmyaqgjiiba',
+    canBeReserved: true,
+  },
+  {
+    category: Categories.MACHINE_ROOM,
+    room: Rooms.MACHINE_ROOM_1,
+    type: SpaceTypes.ELECTRONIC_WORKSTATION,
+    id: '52',
+    respaId: 'awmyd7u2gqjq',
+    canBeReserved: true,
+  },
+  {
+    category: Categories.MACHINE_ROOM,
+    room: Rooms.MACHINE_ROOM_1,
+    type: SpaceTypes.LASER_CUTTER,
+    id: '53',
+    respaId: 'av5k6h56ne7q',
+    canBeReserved: true,
+  },
+  {
+    category: Categories.MACHINE_ROOM,
+    room: Rooms.MACHINE_ROOM_1,
+    type: SpaceTypes.UV_PRINTER,
+    id: '54',
+    respaId: 'av5k6h56ne7q',
     canBeReserved: true,
   },
   {

--- a/app/containers/HomePage/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/HomePage/tests/__snapshots__/index.test.js.snap
@@ -601,7 +601,7 @@ exports[`<HomePage /> should render and match the snapshot 1`] = `
               style="stroke: transparent; fill: #f6f6f8;"
             />
             <path
-              class="roomPath  noData"
+              class="roomPath  available"
               cursor="pointer"
               d="M755.219,52.663L755.219,29.376L812.161,29.376L812.161,5.098L889.297,5.098L889.297,52.663L755.219,52.663Z"
               id="mr1"

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -22,9 +22,12 @@
   "subSpaces.3dPrinters": "3D printers",
   "subSpaces.buttonPinMachine": "",
   "subSpaces.coverstitchMachine": "",
+  "subSpaces.electronicWorkstation": "Electronic workstations ",
   "subSpaces.embroideryMachine": "",
   "subSpaces.largeFormatPrinter": "",
+  "subSpaces.laserCutter": "",
   "subSpaces.overlockMachine": "overlock machines",
   "subSpaces.sewingMachine": "sewing machines",
+  "subSpaces.uvPrinter": "",
   "subSpaces.vinylCutterAndHeatpress": ""
 }

--- a/app/translations/fi.json
+++ b/app/translations/fi.json
@@ -22,9 +22,12 @@
   "subSpaces.3dPrinters": "3D-tulostimet",
   "subSpaces.buttonPinMachine": "Rintanappikone",
   "subSpaces.coverstitchMachine": "Peitetikkikoneet",
+  "subSpaces.electronicWorkstation": "Elektroniikkatyöpisteet",
   "subSpaces.embroideryMachine": "Kirjovat ompelukoneet",
   "subSpaces.largeFormatPrinter": "Suurkuvatulostin",
+  "subSpaces.laserCutter": "Laserleikkuri",
   "subSpaces.overlockMachine": "Saumurit",
   "subSpaces.sewingMachine": "Ompelukoneet",
+  "subSpaces.uvPrinter": "Uv-tulostin",
   "subSpaces.vinylCutterAndHeatpress": "Vinyylileikkuri ja lämpöprässi"
 }

--- a/app/translations/sv.json
+++ b/app/translations/sv.json
@@ -22,9 +22,12 @@
   "subSpaces.3dPrinters": "3d-skrivare",
   "subSpaces.buttonPinMachine": "",
   "subSpaces.coverstitchMachine": "",
+  "subSpaces.electronicWorkstation": "elektroniska arbetsstationer",
   "subSpaces.embroideryMachine": "",
   "subSpaces.largeFormatPrinter": "",
+  "subSpaces.laserCutter": "",
   "subSpaces.overlockMachine": "överlocksmaskiner",
   "subSpaces.sewingMachine": "symaskiner",
+  "subSpaces.uvPrinter": "",
   "subSpaces.vinylCutterAndHeatpress": ""
 }


### PR DESCRIPTION
**Lists content of machine room in its tooltip**  
<img width="290" alt="Screenshot 2020-04-09 at 12 21 10" src="https://user-images.githubusercontent.com/9090689/78879549-b2965d00-7a5c-11ea-876b-2b4d0fcd9fc0.png">

**Disconnects "Kitchen" from respa**  
- Instead of the name in respa ("Kitchen, leaning space 1") we are only displaying "Kitchen"
- We are not chowing a reservation status, because the kitchen has a separate reservation calendar
- We are still showing a hardcoded people count

<img width="271" alt="Screenshot 2020-04-09 at 12 22 16" src="https://user-images.githubusercontent.com/9090689/78879735-f9845280-7a5c-11ea-8ce6-bac6821c2d26.png">
