### PR TITLE
Chore | Refactor tooltip

### DIFF
--- a/app/components/Tooltip/SubSpaceVacancyIcon.js
+++ b/app/components/Tooltip/SubSpaceVacancyIcon.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import VacancyIcon from 'components/VacancyIcon';
+
+function SubSpaceVacancyIcon({ availableCount }) {
+  return (
+    <VacancyIcon
+      className={classNames({
+        available: availableCount > 0,
+        taken: availableCount === 0,
+      })}
+    />
+  );
+}
+
+SubSpaceVacancyIcon.propTypes = {
+  availableCount: PropTypes.number,
+};
+
+export default SubSpaceVacancyIcon;

--- a/app/components/Tooltip/TooltipGrid.js
+++ b/app/components/Tooltip/TooltipGrid.js
@@ -1,23 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
 
-import getSpaceAvailability from 'utils/getSpaceAvailability';
+import SpaceAvailability from 'constants/SpaceAvailability';
 import { vacancyIconColoringCss } from 'components/VacancyIcon';
-import spaceTypeMessages from './spaceTypeMessages';
-import { Title, Row as OneItemRow, RowLabel, Icon } from './wrappers';
-import UserIcon from './icons/UserIcon';
-import messages from './messages';
-
-const Row = styled(OneItemRow)`
-  justify-content: space-between;
-`;
-
-const RowItem = styled.div`
-  display: flex;
-  align-items: center;
-`;
 
 const Center = styled.div`
   display: flex;
@@ -66,24 +52,8 @@ const ItemNumber = styled.div`
   }}
 `;
 
-export const TooltipGrid = ({ groups }) => {
-  if (groups.length === 0) {
-    return null;
-  }
-
-  const [spaceType, spaces] = groups[0];
-  const maxPeopleCount = spaces.length;
-  const someSpaceCanBeReserved = spaces.some(space => space.canBeReserved);
-  const spacesWithOrder = spaces.map((space, index) => ({
-    ...space,
-    order: index + 1,
-  }));
-  const halfwayThrough = Math.floor(spacesWithOrder.length / 2);
-  const adjustedSpaceOrder = [
-    ...spacesWithOrder.slice(halfwayThrough, spacesWithOrder.length).reverse(),
-    ...spacesWithOrder.slice(0, halfwayThrough),
-  ];
-  const topRowLength = Math.ceil(adjustedSpaceOrder.length / 2);
+export const TooltipGrid = ({ items }) => {
+  const topRowLength = Math.ceil(items.length / 2);
 
   const getLabelPosition = index => {
     const isOnTopRow = index + 1 <= topRowLength;
@@ -92,48 +62,30 @@ export const TooltipGrid = ({ groups }) => {
   };
 
   return (
-    <>
-      <Title>
-        <FormattedMessage {...spaceTypeMessages[spaceType]} />
-      </Title>
-      <Row>
-        <RowItem>
-          <Icon>
-            <UserIcon />
-          </Icon>
-          <RowLabel>{maxPeopleCount}</RowLabel>
-        </RowItem>
-        <RowItem>
-          <RowLabel>
-            {someSpaceCanBeReserved && (
-              <FormattedMessage {...messages.reservationStatusLabel} />
-            )}
-            {!someSpaceCanBeReserved && (
-              <FormattedMessage {...messages.notReservableStatusLabel} />
-            )}
-          </RowLabel>
-        </RowItem>
-      </Row>
-      <Center>
-        <Grid maxRowLength={topRowLength}>
-          {adjustedSpaceOrder.map((spaceWithOrder, i) => (
-            <Item
-              key={spaceWithOrder.id}
-              className={getSpaceAvailability(spaceWithOrder)}
-            >
-              <ItemNumber position={getLabelPosition(i)}>
-                {spaceWithOrder.order}
-              </ItemNumber>
-            </Item>
-          ))}
-        </Grid>
-      </Center>
-    </>
+    <Center>
+      <Grid maxRowLength={topRowLength}>
+        {items.map((item, i) => (
+          <Item key={item.id} className={item.availability}>
+            <ItemNumber position={getLabelPosition(i)}>{item.label}</ItemNumber>
+          </Item>
+        ))}
+      </Grid>
+    </Center>
   );
 };
 
 TooltipGrid.propTypes = {
-  groups: PropTypes.array,
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      label: PropTypes.node.isRequired,
+      // Ideally we would make this component agnostic of business
+      // logic, but I skipped a corner here in order to reduce the
+      // complexity of the final code.
+      availability: PropTypes.oneOf(Object.values(SpaceAvailability))
+        .isRequired,
+    }),
+  ),
 };
 
 export default TooltipGrid;

--- a/app/components/Tooltip/TooltipGroup.js
+++ b/app/components/Tooltip/TooltipGroup.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Row, RowLabel } from './wrappers';
+import SubSpaceVacancyIcon from './SubSpaceVacancyIcon';
+
+const TooltipGroup = ({ availableCount, label, totalCount }) => (
+  <Row>
+    <SubSpaceVacancyIcon
+      availableCount={availableCount}
+      totalCount={totalCount}
+    />
+    <RowLabel>{label}</RowLabel>
+  </Row>
+);
+
+TooltipGroup.propTypes = {
+  availableCount: PropTypes.number.isRequired,
+  label: PropTypes.node.isRequired,
+  totalCount: PropTypes.number.isRequired,
+};
+
+export default TooltipGroup;

--- a/app/components/Tooltip/TooltipRow.js
+++ b/app/components/Tooltip/TooltipRow.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Row } from './wrappers';
+
+const TooltipRow = ({ children }) => <Row>{children}</Row>;
+
+TooltipRow.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default TooltipRow;

--- a/app/components/Tooltip/TooltipRowItems.js
+++ b/app/components/Tooltip/TooltipRowItems.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+
+import { Row as OneItemRow } from './wrappers';
+
+const Row = styled(OneItemRow)`
+  justify-content: space-between;
+`;
+
+const RowItem = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const TooltipRowItems = ({ items }) => (
+  <Row>
+    {items.map(item => (
+      <RowItem key={item.id}>{item.content}</RowItem>
+    ))}
+  </Row>
+);
+
+TooltipRowItems.propTypes = {
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      content: PropTypes.node.isRequired,
+      id: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
+};
+
+export default TooltipRowItems;

--- a/app/components/Tooltip/index.js
+++ b/app/components/Tooltip/index.js
@@ -151,8 +151,10 @@ function findSpaceData(spaces, spaceContentType) {
         );
       }
 
-      // SpacesByType should be exactly 1 in length to we an safely only
-      // take the first item into consideration.
+      // SpacesByType should be an array with exactly one item in it.
+      // Because of this, we can:
+      // (1) safely access the first item and
+      // (2) safely ignore other items.
       const [spaceType, spacesWithType] = spacesByType[0];
       const maxPeopleCount = spaces.length;
       const someSpaceCanBeReserved = spaces.some(space => space.canBeReserved);

--- a/app/components/Tooltip/index.js
+++ b/app/components/Tooltip/index.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import groupBy from 'lodash/groupBy';
 import { FormattedMessage, injectIntl } from 'react-intl';
-import classNames from 'classnames';
 import get from 'lodash/get';
 import dateFormat from 'dateformat';
 
@@ -16,9 +15,9 @@ import {
   getNextReservedSlot,
 } from 'utils/resourceSlots';
 import VacancyLabel from 'components/VacancyLabel';
-import VacancyIcon from 'components/VacancyIcon';
 import CloseButton from 'components/CloseButton';
 import categoryMessages from 'components/ButtonList/categoryMessages';
+import TooltipGroup from './TooltipGroup';
 import TooltipGrid from './TooltipGrid';
 import {
   TooltipWrapper,
@@ -39,21 +38,6 @@ const ALLOWED_AVAILABILITIES = [
 ];
 
 const ROOMS_WITH_GRID = [Rooms.WORKSTATION_1, Rooms.WORKSTATION_2];
-
-function SubSpaceVacancyIcon({ availableCount }) {
-  return (
-    <VacancyIcon
-      className={classNames({
-        available: availableCount > 0,
-        taken: availableCount === 0,
-      })}
-    />
-  );
-}
-
-SubSpaceVacancyIcon.propTypes = {
-  availableCount: PropTypes.number,
-};
 
 function getAvailableCount(spaces) {
   const now = new Date();
@@ -104,18 +88,16 @@ function makeBody(content, currentLocal) {
             <Title>
               <FormattedMessage {...categoryMessages[category]} />
             </Title>
-            <Row className="small light">
-              <RowLabel>
-                <FormattedMessage {...spaceTypeMessages[spaceType]} />
-              </RowLabel>
-            </Row>
-            <Row className="small light">
-              <SubSpaceVacancyIcon availableCount={availableCount} />
-              <RowLabel>
-                <FormattedMessage {...messages.reservableStatusLabel} />{' '}
-                {availableCount}/{totalCount}
-              </RowLabel>
-            </Row>
+            <TooltipGroup
+              availableCount={availableCount}
+              label={
+                <>
+                  <FormattedMessage {...spaceTypeMessages[spaceType]} />{' '}
+                  {availableCount}/{totalCount}{' '}
+                  <FormattedMessage {...messages.reservableStatusLabel} />
+                </>
+              }
+            />
           </>
         );
       }
@@ -130,14 +112,17 @@ function makeBody(content, currentLocal) {
             const availableCount = getAvailableCount(spaces);
 
             return (
-              <Row key={spaceType}>
-                <SubSpaceVacancyIcon availableCount={availableCount} />
-                <RowLabel>
-                  <FormattedMessage {...spaceTypeMessages[spaceType]} />{' '}
-                  {availableCount}/{totalCount}{' '}
-                  <FormattedMessage {...messages.reservableStatusLabel} />
-                </RowLabel>
-              </Row>
+              <TooltipGroup
+                key={spaceType}
+                availableCount={availableCount}
+                label={
+                  <>
+                    <FormattedMessage {...spaceTypeMessages[spaceType]} />{' '}
+                    {availableCount}/{totalCount}{' '}
+                    <FormattedMessage {...messages.reservableStatusLabel} />
+                  </>
+                }
+              />
             );
           })}
         </>

--- a/app/components/Tooltip/index.js
+++ b/app/components/Tooltip/index.js
@@ -17,6 +17,7 @@ import {
 import VacancyLabel from 'components/VacancyLabel';
 import CloseButton from 'components/CloseButton';
 import categoryMessages from 'components/ButtonList/categoryMessages';
+import TooltipRowItems from './TooltipRowItems';
 import TooltipGroup from './TooltipGroup';
 import TooltipGrid from './TooltipGrid';
 import {
@@ -31,12 +32,27 @@ import messages from './messages';
 import spaceTypeMessages from './spaceTypeMessages';
 import UserIcon from './icons/UserIcon';
 
+const TooltipContentTypes = Object.freeze({
+  DESCRIPTION: 'tooltipDescription',
+  ROW: 'tooltipRow',
+  ROW_ITEMS: 'tooltipRowItems',
+  GROUP: 'tooltipGroup',
+  GRID: 'tooltipGrid',
+});
+
+const SpaceContentTypes = Object.freeze({
+  EMPTY: 'spaceEmpty',
+  SINGLE: 'spaceSingle',
+  GROUPS: 'spaceGroup',
+  GRID: 'spaceGrid',
+  UNKNOWN: 'spaceUnknown',
+});
+
 const ALLOWED_AVAILABILITIES = [
   SpaceAvailability.AVAILABLE,
   SpaceAvailability.TAKEN,
   SpaceAvailability.CLOSED,
 ];
-
 const ROOMS_WITH_GRID = [Rooms.WORKSTATION_1, Rooms.WORKSTATION_2];
 
 function getAvailableCount(spaces) {
@@ -52,84 +68,36 @@ function getAvailableCount(spaces) {
   return available.length;
 }
 
-function getType(content) {
-  if (content.length > 1) {
-    return 'group';
+function getSpaceContentType(content) {
+  if (content.length === 0) {
+    return SpaceContentTypes.EMPTY;
   }
 
-  return '';
+  if (content.length === 1) {
+    return SpaceContentTypes.SINGLE;
+  }
+
+  const { room } = content.find(space => space.room);
+
+  if (ROOMS_WITH_GRID.includes(room)) {
+    return SpaceContentTypes.GRID;
+  }
+
+  const spaceTypes = Object.keys(groupBy(content, 'type'));
+
+  if (spaceTypes.length > 0) {
+    return SpaceContentTypes.GROUP;
+  }
+
+  return SpaceContentTypes.UNKNOWN;
 }
 
-function makeBody(content, currentLocal) {
-  if (content.length === 0) {
-    return null;
-  }
-
-  const type = getType(content);
-  const translate = translationObject =>
-    getLocalizedString(translationObject, currentLocal);
-
-  switch (type) {
-    case 'group': {
-      const groups = Object.entries(groupBy(content, 'type'));
-      const { category, room } = content[0];
-
-      if (ROOMS_WITH_GRID.includes(room)) {
-        return <TooltipGrid groups={groups} />;
-      }
-
-      if (groups.length === 1) {
-        const [spaceType, spaces] = groups[0];
-        const totalCount = spaces.length;
-        const availableCount = getAvailableCount(spaces);
-
-        return (
-          <>
-            <Title>
-              <FormattedMessage {...categoryMessages[category]} />
-            </Title>
-            <TooltipGroup
-              availableCount={availableCount}
-              label={
-                <>
-                  <FormattedMessage {...spaceTypeMessages[spaceType]} />{' '}
-                  {availableCount}/{totalCount}{' '}
-                  <FormattedMessage {...messages.reservableStatusLabel} />
-                </>
-              }
-            />
-          </>
-        );
-      }
-
-      return (
-        <>
-          <Title>
-            <FormattedMessage {...categoryMessages[category]} />
-          </Title>
-          {groups.map(([spaceType, spaces]) => {
-            const totalCount = spaces.length;
-            const availableCount = getAvailableCount(spaces);
-
-            return (
-              <TooltipGroup
-                key={spaceType}
-                availableCount={availableCount}
-                label={
-                  <>
-                    <FormattedMessage {...spaceTypeMessages[spaceType]} />{' '}
-                    {availableCount}/{totalCount}{' '}
-                    <FormattedMessage {...messages.reservableStatusLabel} />
-                  </>
-                }
-              />
-            );
-          })}
-        </>
-      );
-    }
-    default: {
-      const space = content[0];
+function findSpaceData(spaces, spaceContentType) {
+  switch (spaceContentType) {
+    case SpaceContentTypes.SINGLE: {
+      // Only a single space present so we can safely take the first
+      // one.
+      const space = spaces[0];
       const vacancyStatus = getSpaceAvailability(space);
       const hardCodedMaxPeopleCount = get(space, 'peopleCapacity', null);
       const maxPeopleCount = get(
@@ -143,55 +111,292 @@ function makeBody(content, currentLocal) {
       const closestFreeSlot = getClosestAvailableSlot(data);
       const nextReservedSlot = getNextReservedSlot(data);
 
-      return (
-        <>
-          <Title>{translate(name)}</Title>
-          {maxPeopleCount && (
-            <Row>
+      return {
+        type: SpaceContentTypes.SINGLE,
+        name,
+        vacancyStatus,
+        maxPeopleCount,
+        description,
+        closestFreeSlot,
+        nextReservedSlot,
+      };
+    }
+    case SpaceContentTypes.GROUP: {
+      const { category } = spaces.find(space => space.category);
+      const spacesByType = Object.entries(groupBy(spaces, 'type'));
+      const groups = spacesByType.map(([spaceType, spacesWithType]) => {
+        const totalCount = spacesWithType.length;
+        const availableCount = getAvailableCount(spacesWithType);
+
+        return {
+          id: spaceType,
+          availableCount,
+          totalCount,
+          spaceType,
+        };
+      });
+
+      return {
+        type: SpaceContentTypes.GROUP,
+        category,
+        groups,
+      };
+    }
+    case SpaceContentTypes.GRID: {
+      const spacesByType = Object.entries(groupBy(spaces, 'type'));
+
+      if (spacesByType.length === 0 || spacesByType > 1) {
+        throw Error(
+          'The GRID SpaceContentType supports rendering of exactly one SpaceType group',
+        );
+      }
+
+      // SpacesByType should be exactly 1 in length to we an safely only
+      // take the first item into consideration.
+      const [spaceType, spacesWithType] = spacesByType[0];
+      const maxPeopleCount = spaces.length;
+      const someSpaceCanBeReserved = spaces.some(space => space.canBeReserved);
+      const gridItems = spacesWithType.map((space, index) => ({
+        id: space.id,
+        label: index,
+        availability: getSpaceAvailability(space),
+      }));
+
+      return {
+        type: SpaceContentTypes.GRID,
+        spaceType,
+        maxPeopleCount,
+        someSpaceCanBeReserved,
+        gridItems,
+      };
+    }
+    case SpaceContentTypes.EMPTY:
+      return {
+        type: SpaceContentTypes.EMPTY,
+      };
+    case SpaceContentTypes.UNKNOWN:
+      return {
+        type: SpaceContentTypes.UNKNOWN,
+      };
+    default:
+      return {};
+  }
+}
+
+function makeTooltipViewModel(spaces, currentLocal) {
+  const translate = translationObject =>
+    getLocalizedString(translationObject, currentLocal);
+
+  const spaceContentType = getSpaceContentType(spaces);
+  const spaceData = findSpaceData(spaces, spaceContentType);
+
+  switch (spaceData.type) {
+    case SpaceContentTypes.SINGLE: {
+      const {
+        closestFreeSlot,
+        description,
+        name,
+        nextReservedSlot,
+        maxPeopleCount,
+        vacancyStatus,
+      } = spaceData;
+      const content = [];
+
+      if (maxPeopleCount) {
+        content.push({
+          type: TooltipContentTypes.ROW,
+          id: 'maxPeopleCount',
+          content: (
+            <>
               <Icon>
                 <UserIcon />
               </Icon>
               <RowLabel>{maxPeopleCount}</RowLabel>
-            </Row>
-          )}
-          {description && (
-            <Row>
-              <RowLabel>{translate(description)}</RowLabel>
-            </Row>
-          )}
-          {ALLOWED_AVAILABILITIES.includes(vacancyStatus) && (
-            <Row>
-              <VacancyLabel variant="light" vacancy={vacancyStatus} />
-            </Row>
-          )}
-          {vacancyStatus === SpaceAvailability.AVAILABLE && nextReservedSlot && (
-            <Row>
-              <RowLabel>
-                <FormattedMessage
-                  {...messages.availableUntilTimeLabel}
-                  values={{
-                    time: dateFormat(new Date(nextReservedSlot.start), 'HH:MM'),
-                  }}
-                />
-              </RowLabel>
-            </Row>
-          )}
-          {vacancyStatus === SpaceAvailability.TAKEN && closestFreeSlot && (
-            <Row>
-              <RowLabel>
-                <FormattedMessage
-                  {...messages.nextAvailableTimeLabel}
-                  values={{
-                    time: dateFormat(new Date(closestFreeSlot.start), 'HH:MM'),
-                  }}
-                />
-              </RowLabel>
-            </Row>
-          )}
-        </>
-      );
+            </>
+          ),
+        });
+      }
+
+      if (description) {
+        content.push({
+          type: TooltipContentTypes.DESCRIPTION,
+          id: 'description',
+          description: translate(spaceData.description),
+        });
+      }
+
+      if (ALLOWED_AVAILABILITIES.includes(vacancyStatus)) {
+        content.push({
+          type: TooltipContentTypes.ROW,
+          id: 'vacancyLabel',
+          content: <VacancyLabel variant="light" vacancy={vacancyStatus} />,
+        });
+      }
+
+      if (vacancyStatus === SpaceAvailability.AVAILABLE && nextReservedSlot) {
+        content.push({
+          type: TooltipContentTypes.ROW,
+          id: 'availableUntil',
+          content: (
+            <RowLabel>
+              <FormattedMessage
+                {...messages.availableUntilTimeLabel}
+                values={{
+                  time: dateFormat(new Date(nextReservedSlot.start), 'HH:MM'),
+                }}
+              />
+            </RowLabel>
+          ),
+        });
+      }
+
+      if (vacancyStatus === SpaceAvailability.TAKEN && closestFreeSlot) {
+        content.push({
+          type: TooltipContentTypes.ROW,
+          id: 'availableNext',
+          content: (
+            <RowLabel>
+              <FormattedMessage
+                {...messages.nextAvailableTimeLabel}
+                values={{
+                  time: dateFormat(new Date(closestFreeSlot.start), 'HH:MM'),
+                }}
+              />
+            </RowLabel>
+          ),
+        });
+      }
+
+      return {
+        title: translate(name),
+        content,
+      };
     }
+    case SpaceContentTypes.GROUP: {
+      const { groups, category } = spaceData;
+      const content = groups.map(group => ({
+        type: TooltipContentTypes.GROUP,
+        id: group.id,
+        availableCount: group.availableCount,
+        totalCount: group.totalCount,
+        label: (
+          <>
+            <FormattedMessage {...spaceTypeMessages[group.spaceType]} />{' '}
+            {group.availableCount}/{group.totalCount}{' '}
+            <FormattedMessage {...messages.reservableStatusLabel} />
+          </>
+        ),
+      }));
+
+      return {
+        title: <FormattedMessage {...categoryMessages[category]} />,
+        content,
+      };
+    }
+    case SpaceContentTypes.GRID: {
+      const {
+        maxPeopleCount,
+        someSpaceCanBeReserved,
+        spaceType,
+        gridItems,
+      } = spaceData;
+      const halfwayThrough = Math.floor(gridItems.length / 2);
+      const adjustedGridItemOrder = [
+        ...gridItems.slice(halfwayThrough, gridItems.length).reverse(),
+        ...gridItems.slice(0, halfwayThrough),
+      ];
+
+      return {
+        title: <FormattedMessage {...spaceTypeMessages[spaceType]} />,
+        content: [
+          {
+            type: TooltipContentTypes.ROW_ITEMS,
+            id: 'info',
+            items: [
+              {
+                id: 'maxPeopleCount',
+                content: (
+                  <>
+                    <Icon>
+                      <UserIcon />
+                    </Icon>
+                    <RowLabel>{maxPeopleCount}</RowLabel>
+                  </>
+                ),
+              },
+              {
+                id: 'reservationStatus',
+                content: (
+                  <>
+                    <RowLabel>
+                      {someSpaceCanBeReserved && (
+                        <FormattedMessage
+                          {...messages.reservationStatusLabel}
+                        />
+                      )}
+                      {!someSpaceCanBeReserved && (
+                        <FormattedMessage
+                          {...messages.notReservableStatusLabel}
+                        />
+                      )}
+                    </RowLabel>
+                  </>
+                ),
+              },
+            ],
+          },
+          {
+            type: TooltipContentTypes.GRID,
+            id: 'grid',
+            items: adjustedGridItemOrder,
+          },
+        ],
+      };
+    }
+    case SpaceContentTypes.EMPTY:
+    case SpaceContentTypes.UNKNOWN:
+    default:
+      return null;
   }
+}
+
+function makeBody(content, currentLocal) {
+  const tooltipData = makeTooltipViewModel(content, currentLocal);
+
+  if (!tooltipData) {
+    return null;
+  }
+
+  return (
+    <>
+      <Title>{tooltipData.title}</Title>
+      {tooltipData.content.map(contentItem => (
+        <React.Fragment key={contentItem.id}>
+          {contentItem.type === TooltipContentTypes.DESCRIPTION && (
+            <Row>
+              <RowLabel>{contentItem.description}</RowLabel>
+            </Row>
+          )}
+          {contentItem.type === TooltipContentTypes.ROW && (
+            <Row>{contentItem.content}</Row>
+          )}
+          {contentItem.type === TooltipContentTypes.ROW_ITEMS && (
+            <TooltipRowItems items={contentItem.items} />
+          )}
+          {contentItem.type === TooltipContentTypes.GROUP && (
+            <TooltipGroup
+              availableCount={contentItem.availableCount}
+              label={contentItem.label}
+              totalCount={contentItem.totalCount}
+            />
+          )}
+          {contentItem.type === TooltipContentTypes.GRID && (
+            <TooltipGrid items={contentItem.items} />
+          )}
+        </React.Fragment>
+      ))}
+    </>
+  );
 }
 
 const Tooltip = ({ content, intl, onClick, visible, x, y }) => {


### PR DESCRIPTION
This commit refactors the `Tooltip` to use a MVVM like pattern. This should clear up the convoluted and brittle business logic around the component.

In this context the MVVM-like pattern references the approach where we create an additional layer of abstraction between the "pure" model, and a model that our view component knows how to render.

In essence, we are doing two things:

1) We are making `Tooltip` agnostic of the model it is rendering
2) We are creating a function which transforms the original model into a `Tooltip` compatible version

I'm not entirely convinced that the tooltip here necessarily requires this abstraction--but the relationship between data and what gets rendered is pretty hard to keep track of. To combat that, I wanted to introduce a more formal structure into this component.