### PR TITLE
VAR-374 | Use minimum font-size of 12px

### DIFF
--- a/app/containers/App/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/App/tests/__snapshots__/index.test.js.snap
@@ -5,7 +5,7 @@ exports[`<App /> should render and match the snapshot 1`] = `
   theme={
     Object {
       "fontSize": Array [
-        0.625,
+        0.75,
         0.75,
         0.938,
         1,

--- a/app/containers/HomePage/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/HomePage/tests/__snapshots__/index.test.js.snap
@@ -28,7 +28,7 @@ exports[`<HomePage /> should render and match the snapshot 1`] = `
           </span>
           <br />
           <span
-            class="wrappers__QRCodeLink-sc-12jnkun-8 gtBCPZ"
+            class="wrappers__QRCodeLink-sc-12jnkun-8 czVQIj"
           >
             varaamo.hel.fi
           </span>
@@ -730,7 +730,7 @@ exports[`<HomePage /> should render and match the snapshot 1`] = `
               class="available VacancyIcon-sc-5dhn2h-0 dyrJws"
             />
             <p
-              class="small dark P-a1qszj-0 emFJsd"
+              class="small dark P-a1qszj-0 ebfFrP"
             >
               <span>
                 Vapaa
@@ -748,7 +748,7 @@ exports[`<HomePage /> should render and match the snapshot 1`] = `
               class="taken VacancyIcon-sc-5dhn2h-0 dyrJws"
             />
             <p
-              class="small dark P-a1qszj-0 emFJsd"
+              class="small dark P-a1qszj-0 ebfFrP"
             >
               <span>
                 Varattu
@@ -766,7 +766,7 @@ exports[`<HomePage /> should render and match the snapshot 1`] = `
               class="closed VacancyIcon-sc-5dhn2h-0 dyrJws"
             />
             <p
-              class="small dark P-a1qszj-0 emFJsd"
+              class="small dark P-a1qszj-0 ebfFrP"
             >
               <span>
                 Suljettu

--- a/app/theme/index.js
+++ b/app/theme/index.js
@@ -1,8 +1,9 @@
 export const ROOT_FONT_SIZE = 16; // px
 
 // With a root font size of 16px, these values equal to about the
-// following pixel values: [10, 12, 15, 16, 18, 36, 45]
-const fontSizeRem = [0.625, 0.75, 0.938, 1, 1.125, 2.25, 2.813];
+// following pixel values: [12, 12, 15, 16, 18, 36, 45]
+// Smallest font-size that's visible on the TV screen.
+const fontSizeRem = [0.75, 0.75, 0.938, 1, 1.125, 2.25, 2.813];
 fontSizeRem.get = index => `${fontSizeRem[index]}rem`;
 
 export default {


### PR DESCRIPTION
The font-size of 10px was too small for the big screen this app is used for. According to the testers, 12px was a good size.