### PR TITLE
VAR-374 | Render qr code next to map

### DIFF
--- a/app/components/Container/index.js
+++ b/app/components/Container/index.js
@@ -160,20 +160,6 @@ class Container extends React.Component {
     return (
       <React.Fragment>
         <Wrapper>
-          <QRCodeWrapper>
-            <QRCode
-              link={QRCodeHref}
-              description={
-                <>
-                  <FormattedMessage {...messages.makeReservationInVaraamo}>
-                    {text => <QRCodeDescription>{text}</QRCodeDescription>}
-                  </FormattedMessage>
-                  <br />
-                  <QRCodeLink>{QRCodeLinkValue}</QRCodeLink>
-                </>
-              }
-            />
-          </QRCodeWrapper>
           <H1>
             Oodi{' '}
             <FormattedMessage {...messages.mapTitle}>
@@ -181,6 +167,20 @@ class Container extends React.Component {
             </FormattedMessage>
           </H1>
           <MapWrapper>
+            <QRCodeWrapper>
+              <QRCode
+                link={QRCodeHref}
+                description={
+                  <>
+                    <FormattedMessage {...messages.makeReservationInVaraamo}>
+                      {text => <QRCodeDescription>{text}</QRCodeDescription>}
+                    </FormattedMessage>
+                    <br />
+                    <QRCodeLink>{QRCodeLinkValue}</QRCodeLink>
+                  </>
+                }
+              />
+            </QRCodeWrapper>
             <MapContainer
               spaces={spaces}
               highlighted={highlighted}

--- a/app/components/Container/wrappers.js
+++ b/app/components/Container/wrappers.js
@@ -12,6 +12,7 @@ export const Wrapper = styled.section`
 
 export const MapWrapper = styled.div`
   flex: 1 1;
+  position: relative;
   display: flex;
   flex-direction: column;
   margin-bottom: 38px;
@@ -43,8 +44,8 @@ export const FloorLabel = styled.span`
 
 export const QRCodeWrapper = styled.div`
   position: absolute;
-  top: 69px;
-  right: 100px;
+  top: 0;
+  right: 0;
 `;
 
 export const QRCodeDescription = styled.span`

--- a/app/containers/HomePage/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/HomePage/tests/__snapshots__/index.test.js.snap
@@ -7,34 +7,6 @@ exports[`<HomePage /> should render and match the snapshot 1`] = `
   <section
     class="wrappers__Wrapper-sc-12jnkun-0 hZciOe"
   >
-    <div
-      class="wrappers__QRCodeWrapper-sc-12jnkun-6 jQuvSA"
-    >
-      <div
-        class="QRCode__Wrapper-sc-4gdjit-0 jfXRSe"
-      >
-        <canvas
-          height="70"
-          style="height: 70px; width: 70px;"
-          width="70"
-        />
-        <div
-          class="QRCode__DescriptionWrapper-sc-4gdjit-1 kPrrtZ"
-        >
-          <span
-            class="wrappers__QRCodeDescription-sc-12jnkun-7 bZpGjx"
-          >
-            Tee varaus Varaamossa
-          </span>
-          <br />
-          <span
-            class="wrappers__QRCodeLink-sc-12jnkun-8 czVQIj"
-          >
-            varaamo.hel.fi
-          </span>
-        </div>
-      </div>
-    </div>
     <h1
       class="H1-sc-19ms9d-0 jHTtju"
     >
@@ -47,8 +19,36 @@ exports[`<HomePage /> should render and match the snapshot 1`] = `
       </span>
     </h1>
     <div
-      class="wrappers__MapWrapper-sc-12jnkun-1 hqygag"
+      class="wrappers__MapWrapper-sc-12jnkun-1 bvNErE"
     >
+      <div
+        class="wrappers__QRCodeWrapper-sc-12jnkun-6 LKEPX"
+      >
+        <div
+          class="QRCode__Wrapper-sc-4gdjit-0 jfXRSe"
+        >
+          <canvas
+            height="70"
+            style="height: 70px; width: 70px;"
+            width="70"
+          />
+          <div
+            class="QRCode__DescriptionWrapper-sc-4gdjit-1 kPrrtZ"
+          >
+            <span
+              class="wrappers__QRCodeDescription-sc-12jnkun-7 bZpGjx"
+            >
+              Tee varaus Varaamossa
+            </span>
+            <br />
+            <span
+              class="wrappers__QRCodeLink-sc-12jnkun-8 czVQIj"
+            >
+              varaamo.hel.fi
+            </span>
+          </div>
+        </div>
+      </div>
       <svg
         height="100%"
         version="1.1"


### PR DESCRIPTION
Currently the QR code is rendered on the top right corner of the app. After this change it's rendered on the same level as the map.