### PR TITLE
Add special label for group room 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add closed state for tooltip groups
 - Add "you are here" label into map legend
 - Add not bookable state into map legend
+- Add special label for GROUP_ROOM_1
 
 ### Changed
 - Use pattern instead of solid colour for taken rooms

--- a/app/components/Tooltip/messages.js
+++ b/app/components/Tooltip/messages.js
@@ -23,4 +23,8 @@ export default defineMessages({
     id: `${scope}.nextAvailableTimeLabel`,
     defaultMessage: 'Tila on varattu {time} asti',
   },
+  groupRoomOneSpecialLabel: {
+    id: `${scope}.groupRoomOneSpecialLabel`,
+    defaultMessage: ', vapautuu klo {time}',
+  },
 });

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -12,6 +12,7 @@
   "components.Container.mapTitle": "Helsinki Central Library | 2nd floor",
   "components.MapOfOodi.youAreHere": "You are here",
   "components.Tooltip.availableUntilTimeLabel": "Available until {time}",
+  "components.Tooltip.groupRoomOneSpecialLabel": ", becomes available at {time}",
   "components.Tooltip.nextAvailableTimeLabel": "Available at {time}",
   "components.Tooltip.notReservableStatusLabel": "Not reservable",
   "components.Tooltip.reservableStatusLabel": "Reservable",

--- a/app/translations/fi.json
+++ b/app/translations/fi.json
@@ -12,6 +12,7 @@
   "components.Container.mapTitle": "Helsingin keskustakirjasto | 2.kerros",
   "components.MapOfOodi.youAreHere": "Olet tässä",
   "components.Tooltip.availableUntilTimeLabel": "Tila on vapaana {time} asti",
+  "components.Tooltip.groupRoomOneSpecialLabel": ", vapautuu klo {time}",
   "components.Tooltip.nextAvailableTimeLabel": "Tila on varattu {time} asti",
   "components.Tooltip.notReservableStatusLabel": "Ei varattavissa",
   "components.Tooltip.reservableStatusLabel": "varattavissa",

--- a/app/translations/sv.json
+++ b/app/translations/sv.json
@@ -12,6 +12,7 @@
   "components.Container.mapTitle": "Helsingfors centrumbibliotek | 2:a våningen",
   "components.MapOfOodi.youAreHere": "Du är här",
   "components.Tooltip.availableUntilTimeLabel": "Ledig till kl. {time}",
+  "components.Tooltip.groupRoomOneSpecialLabel": ", blir tillgänglig kl {time}",
   "components.Tooltip.nextAvailableTimeLabel": "Ledig kl. {time}",
   "components.Tooltip.notReservableStatusLabel": "Kan inte reserveras",
   "components.Tooltip.reservableStatusLabel": "Reserverings",


### PR DESCRIPTION
Rooms.GROUP_ROOM_1 behaves in a special way where it's closed until four (Helsinki time) each day, and then becomes available for reservations. This change adds a special label for it, distancing that it'll become available some time today. Without this label, users would think that's it's closed indefinitely.